### PR TITLE
Upgrade i2c-bus to ^4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/adafruit/node_mpr121",
   "dependencies": {
-    "i2c-bus": "^1.0.3"
+    "i2c-bus": "^4.0.2"
   }
 }


### PR DESCRIPTION
Upgrading `i2c-bus` fixes this error:
```
TypeError: domain.enter is not a function
    at topLevelDomainCallback (domain.js:101:12)
```
This is a fix for issue https://github.com/adafruit/node_mpr121/issues/7