### PR TITLE
Upgrade i2c-bus to ^5.2 to fix Raspberry Pi Zero Raspian Buster issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,30 @@ sudo apt-get install i2c-tools
 
 Make sure you follow these [steps to enable autoloading of I2C Kernel module](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-4-gpio-setup/configuring-i2c#installing-kernel-support-with-raspi-config-5-4).
 
-Install Node.js if not yet installed, e.g. to install Node v10:
+#### Node.js install
+
+Install Node.js if not yet installed.
+
+##### Raspberry Pi Zero - Node.js install
+
+To install Node v11, which supports Zero's ARMv6 processor:
 
 ```sh
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+curl -O https://nodejs.org/dist/latest-v11.x/node-v11.15.0-linux-armv6l.tar.gz
+tar -xvzf node-v11.15.0-linux-armv6l.tar.gz
+
+sudo cp -r node-v11.15.0-linux-armv6l/* /usr/local/
+
+$ node -v
+v11.15.0
+```
+
+##### Other Raspberry Pi - Node.js install
+
+For example to install Node v11:
+
+```sh
+curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
@@ -39,8 +59,10 @@ You can check Node version like this:
 
 ```sh
 node -v
-# v10.11.0
+# v11.15.0
 ```
+
+#### Install in your application
 
 To install `adafruit-mpr121` in your own Node app:
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/adafruit/node_mpr121",
   "dependencies": {
-    "i2c-bus": "^4.0.2"
+    "i2c-bus": "^5.2"
   }
 }


### PR DESCRIPTION
Upgrade `i2c-bus` to `^5.2` to fix compilation issue on Raspberry Pi Zero running Raspian Buster with Node.js `v11.15.0`.

Update README with Node.js install steps for Raspberry Pi Zero.

Confirmed manually that upgrade `i2c-bus` to `^5.2` works on Raspberry Pi Zero running Raspian Buster with Node.js `v11.15.0`.